### PR TITLE
Restricts movements when destroying a barricade until the action is r…

### DIFF
--- a/Objects/Obstruction/Obstruction.gd
+++ b/Objects/Obstruction/Obstruction.gd
@@ -40,6 +40,7 @@ func stopDamage():
 		return
 	# Pause the timer
 	timer.set_paused(true)
+	decay_bar.hide()
 
 func destroy():
 	self.queue_free()

--- a/Objects/Player/Player.gd
+++ b/Objects/Player/Player.gd
@@ -12,14 +12,15 @@ var motion: Vector2 = Vector2()
 var speed: int = 80
 var animation = ""
 var attacking = false
+var destroying_obstruction = false
 
 func _ready():
 	pass
 	
 func _input(event):
-	if (event.is_action_pressed("player_left")):
+	if (event.is_action_pressed("player_left")) && !self.destroying_obstruction:
 		Sprite.set_flip_h(true)
-	elif (event.is_action_pressed("player_right")):
+	elif (event.is_action_pressed("player_right")) && !self.destroying_obstruction:
 		Sprite.set_flip_h(false)
 
 	if (event.is_action_pressed("player_action")):
@@ -32,19 +33,20 @@ func get_input():
 	# Detect up/down/left/right keystate and only move when pressed.
 	self.motion = Vector2()
 
-	if Input.is_action_pressed('player_right'):
-		self.motion.x += 1
-		ray.set_cast_to(Vector2(16, 0))
-	if Input.is_action_pressed('player_left'):
-		self.motion.x -= 1
-		ray.set_cast_to(Vector2(-16, 0))
-	if Input.is_action_pressed('player_down'):
-		self.motion.y += 1
-		ray.set_cast_to(Vector2(0, 16))
-	if Input.is_action_pressed('player_up'):
-		self.motion.y -= 1
-		ray.set_cast_to(Vector2(0, -16))
-	self.motion = self.motion.normalized() * speed
+	if (!self.destroying_obstruction):
+		if Input.is_action_pressed('player_right'):
+			self.motion.x += 1
+			ray.set_cast_to(Vector2(16, 0))
+		if Input.is_action_pressed('player_left'):
+			self.motion.x -= 1
+			ray.set_cast_to(Vector2(-16, 0))
+		if Input.is_action_pressed('player_down'):
+			self.motion.y += 1
+			ray.set_cast_to(Vector2(0, 16))
+		if Input.is_action_pressed('player_up'):
+			self.motion.y -= 1
+			ray.set_cast_to(Vector2(0, -16))
+		self.motion = self.motion.normalized() * speed
 	
 	# Set Animation
 	if !attacking:
@@ -59,6 +61,7 @@ func get_input():
 		# When colliding with an obstruction, the action is to remove it
 		if collider.is_in_group("Obstructions"):
 			collider.damage()
+			self.destroying_obstruction = true
 			if !HitBarrierAudioPlayer.playing:
 				HitBarrierAudioPlayer.play()
 		# When colliding with the vehicle, the action is to deposit your collectibles into it
@@ -73,6 +76,9 @@ func get_input():
 				set_parts_sprite("")
 	elif Input.is_action_just_released("player_action") && ray.is_colliding() && ray.get_collider().is_in_group("Obstructions"):
 		ray.get_collider().stopDamage()
+		self.destroying_obstruction = false
+	elif !ray.is_colliding():
+		self.destroying_obstruction = false
 
 func set_parts_sprite(texturePath: String):
 	if (texturePath == ""):


### PR DESCRIPTION
…eleased

* Resolves a bug where the player could walk away from a barricade but still actively destroy it. Moving / changing the raycast and returning would then accelerate the decay bar timer.
* This update restricts movement while destroying a barricade. As soon as the action button is released, we hide the decay bar and can return to normal movement. This works for both holding the action button and mashing it.